### PR TITLE
Switch to Revolt API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Install, build, and upload your site
               uses: withastro/action@v3
               env:
-                  DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+                  REVOLT_TOKEN: ${{ secrets.REVOLT_TOKEN }}
                   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
     deploy:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,5 @@ import icon from 'astro-icon'
 export default defineConfig({
     integrations: [icon()],
     site: 'https://linkdiscord.xyz',
-    image: { domains: ['cdn.discordapp.com'] }
+    image: { domains: ['autumn.revolt.chat'] }
 })

--- a/favicon.mjs
+++ b/favicon.mjs
@@ -2,10 +2,10 @@ import sharp from 'sharp'
 import { createCanvas, loadImage } from 'canvas'
 
 const id = '476662199872651264'
-const token = process.env.DISCORD_TOKEN
+const token = process.env.REVOLT_TOKEN
 
 if (!token) {
-    console.error('Missing DISCORD_TOKEN environment variable')
+    console.error('Missing REVOLT_TOKEN environment variable')
     process.exit(1)
 }
 
@@ -54,9 +54,9 @@ async function generateButton(buffer) {
 
 try {
     const start = process.hrtime.bigint()
-    const userResponse = await fetch(`https://discord.com/api/v10/users/${id}`, {
+    const userResponse = await fetch(`https://api.revolt.chat/users/${id}`, {
         headers: {
-            Authorization: `Bot ${token}`
+            'X-Bot-Token': token
         }
     })
 
@@ -64,7 +64,11 @@ try {
 
     const user = await userResponse.json()
     const avatar = user.avatar
-    const response = await fetch(`https://cdn.discordapp.com/avatars/${id}/${avatar}.png?size=256`)
+    const response = await fetch(
+        user.avatar
+            ? `https://autumn.revolt.chat/${avatar.tag}/${avatar._id}/${avatar.filename}`
+            : `https://api.revolt.chat/users/${id}/default_avatar`
+    )
 
     if (!response.ok) throw new Error('Failed to fetch avatar')
 

--- a/src/components/Friends.astro
+++ b/src/components/Friends.astro
@@ -2,9 +2,9 @@
 import { Image } from 'astro:assets'
 import { getSecret } from 'astro:env/server'
 
-const token = getSecret('DISCORD_TOKEN')
+const token = getSecret('REVOLT_TOKEN')
 
-if (!token) throw new Error('No DISCORD_TOKEN secret')
+if (!token) throw new Error('No REVOLT_TOKEN secret')
 
 const friends: any[] = [
     {
@@ -19,20 +19,21 @@ const friends: any[] = [
 
 for (let i = 0; i < friends.length; i++) {
     const friend = friends[i]
-    const response = await fetch(`https://discord.com/api/v10/users/${friend.id}`, {
+    const response = await fetch(`https://api.revolt.chat/users/${friend.id}`, {
         headers: {
-            Authorization: `Bot ${token}`
+            'X-Bot-Token': token
         }
     })
 
     if (response.ok) {
         const data = await response.json()
-        const animated = data.avatar.startsWith('a_')
-        const extension = animated ? 'gif' : 'webp'
-        const avatar = `${data.avatar}.${extension}?size=512`
+        if (data.avatar) {
+            friends[i].avatar = `https://autumn.revolt.chat/${data.avatar.tag}/${data.avatar._id}/${data.avatar.filename}`
+        } else {
+            friends[i].avatar = `https://api.revolt.chat/users/${friend.id}/default_avatar`
+        }
 
         friends[i].name = data.username
-        friends[i].avatar = `https://cdn.discordapp.com/avatars/${friend.id}/${avatar}`
     }
 }
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,11 +7,11 @@ import { SchemaType } from '@google/generative-ai/server'
 
 import Friends from '../components/Friends.astro'
 
-const discord_token = getSecret('DISCORD_TOKEN')
+const revolt_token = getSecret('REVOLT_TOKEN')
 const gemini_key = getSecret('GEMINI_API_KEY')
 const id = '476662199872651264'
 
-if (!discord_token) throw new Error('No DISCORD_TOKEN secret')
+if (!revolt_token) throw new Error('No REVOLT_TOKEN secret')
 if (!gemini_key) throw new Error('No GEMINI_API_KEY secret')
 
 let displayName = ''
@@ -42,8 +42,8 @@ const model = genAI.getGenerativeModel({
     }
 })
 
-const response = await fetch(`https://discord.com/api/v10/users/${id}`, {
-    headers: { Authorization: `Bot ${discord_token}` }
+const response = await fetch(`https://api.revolt.chat/users/${id}`, {
+    headers: { 'X-Bot-Token': revolt_token }
 })
 
 function componentToHex(c: number) {
@@ -80,18 +80,19 @@ function hexToRGBA(hex: string, transparency = 1) {
 
 if (response.ok) {
     const data = await response.json()
-    const animated = data.avatar.startsWith('a_')
-    const extension = animated ? 'gif' : 'webp'
 
-    avatar = `https://cdn.discordapp.com/avatars/${id}/${data.avatar}.${extension}?size=512`
-    displayName = data.global_name
+    if (data.avatar) {
+        avatar = `https://autumn.revolt.chat/${data.avatar.tag}/${data.avatar._id}/${data.avatar.filename}`
+    } else {
+        avatar = `https://api.revolt.chat/users/${id}/default_avatar`
+    }
+
+    displayName = data.display_name ?? data.username
     username = data.username
 
-    const imageResponse = await fetch(
-        `https://cdn.discordapp.com/avatars/${id}/${data.avatar}.png?size=512`
-    )
+    const imageResponse = await fetch(avatar)
 
-    if (!imageResponse.ok) throw new Error('Couldnt fetch the avatar from discord')
+    if (!imageResponse.ok) throw new Error('Couldnt fetch the avatar from revolt')
 
     const imageBuffer = await imageResponse.arrayBuffer()
     let prompt = ''


### PR DESCRIPTION
## Summary
- fetch user info and avatars from Revolt API instead of Discord
- adjust fetches used to generate favicons
- update friend list to use Revolt API
- configure allowed image host to autumn.revolt.chat
- update workflow secrets to REVOLT_TOKEN

## Testing
- `npm run build` *(fails: Cannot find package 'sharp')*

------
https://chatgpt.com/codex/tasks/task_e_684fde7eefc0832aa6edf0f0bc9c960b